### PR TITLE
fix bugs in log_metrics_callback and vizier output_dir naming

### DIFF
--- a/src/skai/model/log_metrics_callback.py
+++ b/src/skai/model/log_metrics_callback.py
@@ -1,0 +1,146 @@
+"""Keras callback for logging metrics to XManager."""
+
+import abc
+from typing import Mapping, Optional, Sequence, Union
+
+import tensorflow as tf
+
+
+_ScalarMetric = Union[float, int]
+_MetricDict = Mapping[str, _ScalarMetric]
+
+
+class MetricLogger(abc.ABC):
+  """Abstract base class for logging metrics.
+
+  `MetricLoggers` are typically used in conjunction with the
+  `LogMetricsCallback`.
+  """
+
+  @abc.abstractmethod
+  def log_scalar_metric(
+      self, metric_label: str, metric_value: _ScalarMetric, step: int,
+      is_val_metric: bool
+      ) -> None:
+    """Logs a metric name and value at the specified step.
+
+    For example, to log the training accuracy at the end of the first epoch, one
+    might call this function as:
+
+      `log_scalar_metric('epoch_accuracy', 0.89, examples_per_epoch, False)`.
+
+    Args:
+      metric_label: The name of the metric being logged. Typically we assume the
+        'val_' prefix for validation metrics has been removed from the metric
+        label prior to being passed to this function, and that a prefix of
+        'epoch_' or 'batch_' has been added to the metric label to indicate if
+        this metric corresponds to an epoch or a batch. See the
+        `LogMetricsCallback` for more details.
+      metric_value: The value of the metric being logged.
+      step: The step number at which to log this metric. Metrics are normally
+        visualized on `metric_value` vs. `step` plots (e.g., on XManager or
+        TensorBoard). The `LogMetricsCallback` sets this value equal to the
+        number of training steps that have been seen up to the point the metric
+        is logged.
+      is_val_metric: A boolean specifying whether this metric was computed on a
+        validation set.
+    """
+
+
+
+
+class LogMetricsCallback(tf.keras.callbacks.Callback):
+  """A callback for logging metrics, for example to TensorBoard or XManager.
+
+  During training, this callback will log all metrics after every training batch
+  where the total number of examples seen up to that point in the training epoch
+  is a multiple of the specified logging frequency, as well as at the end of
+  every epoch. This callback logs metrics by invoking the `log_scalar_metric`
+  function on all the metric loggers that are provided to the callback's
+  constructor. The metric loggers are objects, such as `XManagerMetricLogger`
+  and `TensorBoardMetricLogger`, which derive from `MetricLogger`.
+  """
+
+  def __init__(
+      self,
+      metric_loggers: Sequence[MetricLogger],
+      logging_frequency: int,
+      batch_size: int,
+      num_train_examples_per_epoch: int,
+      ) -> None:
+    """Initializes the `LogMetricsCallback`.
+
+    Args:
+      metric_loggers: A list of `MetricLogger` objects that are invoked to log
+        training/validation metrics during the course of a Keras training run.
+      logging_frequency: How frequently, in terms of the number of training
+        examples seen during an epoch, to log metrics. For example, if
+        `logging_frequency` is 128, and batch_size is 64, then the metrics would
+        get logged every other batch. `logging_frequency` must be a multiple of
+        `batch_size`.
+      batch_size: The batch size used during training.
+      num_train_examples_per_epoch: The total number of training examples seen
+        during the course of an epoch.
+    """
+    super().__init__()
+    if not metric_loggers:
+      raise ValueError('Must specify at least one MetricLogger.')
+    if logging_frequency % batch_size != 0:
+      raise ValueError(
+          'logging_frequency must be a multiple of batch_size.'
+          )
+    self._metric_loggers = metric_loggers
+    self._logging_frequency = logging_frequency
+    self._batch_size = batch_size
+    self._num_train_examples_per_epoch = num_train_examples_per_epoch
+    self._epoch = -1
+
+  def _log_metrics(
+      self, logs: _MetricDict, num_examples_seen: int,
+      metric_format_str: str, is_val_metric: bool = False,
+      ) -> None:
+    """Logs all metrics in 'logs' dictionary."""
+    for metric_name, metric_value in logs.items():
+      metric_label = metric_format_str.format(metric_name)
+      for metric_logger in self._metric_loggers:
+        metric_logger.log_scalar_metric(
+            metric_label, metric_value, num_examples_seen, is_val_metric,
+            )
+
+  def on_epoch_begin(
+      self, epoch: int, logs: Optional[_MetricDict] = None
+      ) -> None:
+    """Stores the epoch number at the beginning of every epoch."""
+    self._epoch = epoch
+
+  def on_epoch_end(
+      self, epoch: int, logs: Optional[_MetricDict] = None
+      ) -> None:
+    """Logs all metrics at the end of every epoch."""
+    num_examples_seen = (epoch + 1) * self._num_train_examples_per_epoch
+    if logs:
+      # Separate the train vs. validation metrics in `logs`, and log them.
+      train_metrics = {metric_name: metric_value
+                       for metric_name, metric_value in logs.items()
+                       if not metric_name.startswith('val_')}
+      val_metrics = {metric_name.replace('val_', ''): metric_value
+                     for metric_name, metric_value in logs.items()
+                     if metric_name.startswith('val_')}
+      self._log_metrics(train_metrics, num_examples_seen, 'epoch_{}',
+                        is_val_metric=False)
+      self._log_metrics(val_metrics, num_examples_seen, 'epoch_{}',
+                        is_val_metric=True)
+
+  def on_train_batch_end(
+      self, batch: int, logs: Optional[_MetricDict] = None
+      ) -> None:
+    """Logs all metrics after training batches at specified intervals."""
+    num_examples_seen_in_prior_epochs = (self._epoch *
+                                         self._num_train_examples_per_epoch)
+    num_examples_seen_in_this_epoch = (batch + 1) * self._batch_size
+    num_examples_seen_total = (num_examples_seen_in_prior_epochs +
+                               num_examples_seen_in_this_epoch)
+    if logs and num_examples_seen_in_this_epoch % self._logging_frequency == 0:
+      # Log all the metrics in the `logs` dictionary.
+      self._log_metrics(logs, num_examples_seen_total, 'batch_{}',
+                        is_val_metric=False)

--- a/src/skai/model/train.py
+++ b/src/skai/model/train.py
@@ -4,7 +4,6 @@ r"""Binary to run training on a single model once.
 # pylint: enable=line-too-long
 """
 
-import datetime
 import logging as native_logging
 import os
 
@@ -117,11 +116,9 @@ def main(_) -> None:
       reweighting_signal=config.reweighting.signal
   )
   model_params.train_bias = config.train_bias
-  output_dir = config.output_dir
-  start_time = datetime.datetime.now()
-  timestamp = start_time.strftime('%Y-%m-%d-%H%M%S')
-  output_dir = f'{output_dir}_{timestamp}'
 
+  work_unit = os.path.basename(FLAGS.trial_name)
+  output_dir = os.path.join(config.output_dir, work_unit)
   tf.io.gfile.makedirs(output_dir)
   example_id_to_bias_table = None
 

--- a/src/skai/model/train_lib.py
+++ b/src/skai/model/train_lib.py
@@ -438,7 +438,7 @@ def create_callbacks(
     callbacks.append(early_stopping_callback)
 
   if is_vertex:
-    metric_logger = xmanager_external_metric_logger.XMangerMetricLogger(
+    metric_logger = xmanager_external_metric_logger.XManagerMetricLogger(
         vizier_trial_name)
     hyperparameter_tuner_callback = log_metrics_callback.LogMetricsCallback(
         [metric_logger],

--- a/src/skai/model/xm_launch_single_model_vertex.py
+++ b/src/skai/model/xm_launch_single_model_vertex.py
@@ -183,7 +183,8 @@ def main(_) -> None:
     ])
 
     job_args = {
-        'config.output_dir': config.output_dir,
+        'config.output_dir': os.path.join(config.output_dir, 
+                                     str(experiment.experiment_id)),
         'config.train_bias': config.train_bias,
         'config.train_stage_2_as_ensemble': False,
         'config.round_idx': 0,

--- a/src/skai/model/xmanager_helper_module.py
+++ b/src/skai/model/xmanager_helper_module.py
@@ -1,3 +1,8 @@
+"""
+Code in this module is adapted from the XManager repo as a temporary workaround for TypeError when importing xm from xmanager in python 3.8.
+Code source: https://github.com/deepmind/xmanager/tree/main/xmanager/vizier/vizier_cloud
+"""
+
 import re
 import time
 import abc
@@ -5,11 +10,6 @@ from absl import logging
 from xmanager.cloud import auth
 from typing import Any, Dict, Optional
 from google.cloud import aiplatform_v1beta1 as aip
-
-"""
-Code in this module is adapted from the XManager repo as a temporary workaround for TypeError when importing xm from xmanager in python 3.8.
-Code source: https://github.com/deepmind/xmanager/tree/main/xmanager/vizier/vizier_cloud
-"""
 
 _DEFAULT_LOCATION = 'us-central1'
 


### PR DESCRIPTION
Description
- Fixes bugs results from misspelled class name.
- Renames output directory to avoid collisions when many parallel trials are launched together on vizier. 

Types of changes
- Misspelled classnames are corrected
- Output directory where models and other assets are saved are now renamed from ```<base_dir>/<experiment_name>_<datetime>``` to ```<base_dir>/<experiment_name>/<experiment_id>/<work_unit_id>```.